### PR TITLE
Remove non-read routes for skills

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@
 Rails.application.routes.draw do
   # RESTful routes
   resources :characters, except: %i[new edit]
-  resources :skills, except: %i[new edit]
+  resources :skills, except: %i[new edit create update destroy]
   resources :character_skills, except: %i[new edit]
 
   # Custom routes

--- a/curl-scripts/skills/destroy.sh
+++ b/curl-scripts/skills/destroy.sh
@@ -1,0 +1,8 @@
+# Ex: ID=idgoeshere TOKEN=tokengoeshere sh curl-scripts/examples/destroy.sh
+
+curl "http://localhost:4741/skills/${ID}" \
+  --include \
+  --request DELETE \
+  --header "Authorization: Token token=${TOKEN}" \
+
+echo

--- a/curl-scripts/skills/update.sh
+++ b/curl-scripts/skills/update.sh
@@ -1,0 +1,14 @@
+# Ex: TOKEN=tokengoeshere ID=idgoeshere TEXT=textgoeshere sh curl-scripts/examples/update.sh
+
+curl "http://localhost:4741/skills/${ID}" \
+  --include \
+  --request PATCH \
+  --header "Content-Type: application/json" \
+  --header "Authorization: Token token=${TOKEN}" \
+  --data '{
+    "skill": {
+      "name": "'"${NAME}"'"
+    }
+  }'
+
+  echo

--- a/spec/routing/skills_routing_spec.rb
+++ b/spec/routing/skills_routing_spec.rb
@@ -12,22 +12,23 @@ RSpec.describe SkillsController, type: :routing do
       expect(:get => "/skills/1").to route_to("skills#show", :id => "1")
     end
 
+    # routes which edit data for skills have been removed
 
-    it "routes to #create" do
-      expect(:post => "/skills").to route_to("skills#create")
-    end
-
-    it "routes to #update via PUT" do
-      expect(:put => "/skills/1").to route_to("skills#update", :id => "1")
-    end
-
-    it "routes to #update via PATCH" do
-      expect(:patch => "/skills/1").to route_to("skills#update", :id => "1")
-    end
-
-    it "routes to #destroy" do
-      expect(:delete => "/skills/1").to route_to("skills#destroy", :id => "1")
-    end
+    # it "routes to #create" do
+    #   expect(:post => "/skills").to route_to("skills#create")
+    # end
+    #
+    # it "routes to #update via PUT" do
+    #   expect(:put => "/skills/1").to route_to("skills#update", :id => "1")
+    # end
+    #
+    # it "routes to #update via PATCH" do
+    #   expect(:patch => "/skills/1").to route_to("skills#update", :id => "1")
+    # end
+    #
+    # it "routes to #destroy" do
+    #   expect(:delete => "/skills/1").to route_to("skills#destroy", :id => "1")
+    # end
 
   end
 end


### PR DESCRIPTION
Create, update, and destroy routes for skills are excluded, since they
are not owned by users, and specs say: "Any actions which change data
must be authenticated and the data must be "owned" by the user
performing the change."